### PR TITLE
This should improve flask result for json output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ bench: $(VIRTUAL_ENV)
 	# flask
 	@make flask OPTS="-p pid -D -w 2"
 	@sleep 2
-	@TESTEE=flask $(WRK) http://127.0.0.1:5000/json
+	@TESTEE=flask $(WRK) -H "X-Requested-With: XMLHttpRequest" http://127.0.0.1:5000/json
 	@TESTEE=flask $(WRK) http://127.0.0.1:5000/remote
 	@TESTEE=flask $(WRK) http://127.0.0.1:5000/complete
 	@kill `cat $(CURDIR)/pid`


### PR DESCRIPTION
If flask does not receive the X-Requested-With: XMLHttpRequest header on a request which responds with jsonify, it will format the output, slowing dow the response time quite a lot. This PR fixes this. Flask bench should be faster, now.
