### PR TITLE
Django app should not be in debug mode

### DIFF
--- a/frameworks/django/app.py
+++ b/frameworks/django/app.py
@@ -5,7 +5,7 @@ from . import views
 
 settings.configure(
     SECRET_KEY='nosecret',
-    DEBUG=True,
+    DEBUG=False,
     ROOT_URLCONF = views,
 )
 


### PR DESCRIPTION
Django even has "memory leak" in debug mode, because it stores all database queries for debugging purposes.

I'm not sure how much overhead debug mode adds to Django, but benchmark should run in production mode.