### PR TITLE
Speedup Sanic, fix Makefile to be more portable, fix Dockerfile to omit pip version check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.9-slim
 RUN apt-get update && \
     apt-get -y install --no-install-recommends build-essential
 
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
 RUN /usr/local/bin/pip install --no-cache-dir \
     wheel \
     gunicorn \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 DATE = $(shell date +'%Y-%m-%d')
 VIRTUAL_ENV ?= env
 
+ifeq ($(shell uname -s), Linux)
+	HOSTNAME := localhost
+else
+	HOSTNAME := host.docker.internal
+endif
+
 $(VIRTUAL_ENV): frameworks/*/requirements.txt
-	@[ -d $(VIRTUAL_ENV) ] || python -m venv $(VIRTUAL_ENV)
+	@[ -d $(VIRTUAL_ENV) ] || python3 -m venv $(VIRTUAL_ENV)
 	find frameworks | grep requirements | xargs -n1 $(VIRTUAL_ENV)/bin/pip install -r
 	touch $(VIRTUAL_ENV)
 
@@ -36,7 +42,7 @@ clean:
 
 .PHONY: render
 render: $(VIRTUAL_ENV)
-	$(VIRTUAL_ENV)/bin/python render/render.py
+	$(VIRTUAL_ENV)/bin/python3 render/render.py
 	mkdir -p $(CURDIR)/results/$(DATE)
 	cp $(CURDIR)/results/*.csv $(CURDIR)/results/$(DATE)/.
 
@@ -65,25 +71,25 @@ benchmark: clean
 %:
 	@echo "\nBenchmarking $@\n--------------------"
 	@docker build -f $(CURDIR)/frameworks/Dockerfile -t benchmarks:$@ $(CURDIR)/frameworks/$@
-	@docker run --rm -d --publish 8080:8080 --name benchmark benchmarks:$@
+	@docker run --rm -d --publish 8080:8080 --name $@-benchmark benchmarks:$@
 	@echo "\nRun HTML [$@]\n"
 	@docker run --rm --network host \
 	       -e FRAMEWORK=$@ -e FILENAME=/results/html.csv \
 	       -v $(CURDIR)/results:/results \
 	       -v $(CURDIR)/wrk:/scripts \
-	       williamyeh/wrk http://host.docker.internal:8080/html -d15s -t4 -c64 -s /scripts/html.lua
+	       williamyeh/wrk http://${HOSTNAME}:8080/html -d15s -t4 -c64 -s /scripts/html.lua
 	@echo "\nRun UPLOAD [$@]\n"
 	@docker run --rm --network host \
 	       -e FRAMEWORK=$@ -e FILENAME=/results/upload.csv \
 	       -v $(CURDIR)/results:/results \
 	       -v $(CURDIR)/wrk:/scripts \
-	       williamyeh/wrk http://host.docker.internal:8080/upload -d15s -t4 -c64 -s /scripts/upload.lua
+	       williamyeh/wrk http://${HOSTNAME}:8080/upload -d15s -t4 -c64 -s /scripts/upload.lua
 	@echo "\nRun API [$@]\n"
 	@docker run --rm --network host \
 	       -e FRAMEWORK=$@ -e FILENAME=/results/api.csv \
 	       -v $(CURDIR)/results:/results \
 	       -v $(CURDIR)/wrk:/scripts \
-	       williamyeh/wrk http://host.docker.internal:8080/api/users/1/records/1?query=test -d15s -t4 -c64 -s /scripts/api.lua
+	       williamyeh/wrk http://${HOSTNAME}:8080/api/users/1/records/1?query=test -d15s -t4 -c64 -s /scripts/api.lua
 	@echo "\nFinish [$@]\n"
-	@docker stop benchmark
+	@docker kill $@-benchmark
 	sleep 1

--- a/frameworks/sanic/start.sh
+++ b/frameworks/sanic/start.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 
+# the fastest way
+sanic --host 0.0.0.0 --port=8080 --workers=1 app:app
 
-/usr/local/bin/gunicorn -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8080 app:app
+# /usr/local/bin/gunicorn -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8080 app:app
+
+# /usr/local/bin/gunicorn -k sanic.worker.GunicornWorker -b 0.0.0.0:8080 app:app


### PR DESCRIPTION
1. See issue #139 for Sanic speedup explanation.
2. On my openSUSE Leap 15.3 desktop (and on any GNU/Linux host probably) `host.docker.internal` can't be resolved, and default Python is 2.7, so I fixed Makefile to run (hopefully) everywhere.
3. `PIP_DISABLE_PIP_VERSION_CHECK=1`